### PR TITLE
Include header for INT_MIN for unix platforms.

### DIFF
--- a/platform/unix_platform.h
+++ b/platform/unix_platform.h
@@ -38,6 +38,9 @@
 // memset
 #include <cstring>
 
+// INT_MIN
+#include <climits>
+
 #define PLATFORM_RUNTIME_LIB_EXTENSION ".so"
 
 #define WindowEventMasks StructureNotifyMask | PointerMotionMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask


### PR DESCRIPTION
Fixes failing build on Linux.