### PR TITLE
Updated UI windowing logic to keep dynamic sized windows within app window bounds.

### DIFF
--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -2380,17 +2380,18 @@ FlushCommandBuffer(renderer_2d *Group, render_state *RenderState, ui_render_comm
 
         if (TypedCommand->Window->Flags & WindowLayoutFlag_StartupAlign_Right)
         {
-          TypedCommand->Window->Basis.x = Group->ScreenDim->x - TypedCommand->Window->MaxClip.x - DefaultWindowSideOffset;
+          TypedCommand->Window->Basis.x = Max(Group->ScreenDim->x - TypedCommand->Window->MaxClip.x - DefaultWindowSideOffset, DefaultWindowSideOffset);
         }
 
         if (TypedCommand->Window->Flags & WindowLayoutFlag_StartupAlign_Bottom)
         {
-          TypedCommand->Window->Basis.y = Group->ScreenDim->y - TypedCommand->Window->MaxClip.y - DefaultWindowSideOffset;
+          TypedCommand->Window->Basis.y = Max(Group->ScreenDim->y - TypedCommand->Window->MaxClip.y - DefaultWindowSideOffset, DefaultLayout->DrawBounds.Max.y + DefaultWindowSideOffset);
         }
 
         if (TypedCommand->Window->Flags & WindowLayoutFlag_DynamicSize)
         {
-          TypedCommand->Window->MaxClip = RenderState->Layout->DrawBounds.Max;
+          TypedCommand->Window->MaxClip.x = Min(Group->ScreenDim->x - TypedCommand->Window->Basis.x, RenderState->Layout->DrawBounds.Max.x);
+          TypedCommand->Window->MaxClip.y = Min(Group->ScreenDim->y - TypedCommand->Window->Basis.y, RenderState->Layout->DrawBounds.Max.y);
         }
 
 


### PR DESCRIPTION
Notes:

* Not positive this is the right fix. Drag a dynamically sized window downwards and it stays in the screen. Drag it rightwards far enough, and its right edge will stop being contained within the bounds of the app window.
* I tried having `WindowLayoutFlag_StartupAlign_Right` execute just once (removing flag when it runs), but that caused the Basis.x to never be correct. Doing a similar thing for `WindowLayoutFlag_StartupAlign_Bottom` seemed to work just fine.
